### PR TITLE
Cran errors

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,1 @@
+^LICENSE$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,1 +1,2 @@
 ^LICENSE$
+^\.travis\.yml$

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+# R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
+
+language: R
+cache: packages

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: regress
-Version: 1.3-16
-Date: 2017-03-05
+Version: 1.3-17
+Date: 2020-06-11
 Title: Gaussian Linear Models with Linear Covariance Structure
 Author: David Clifford and Peter McCullagh. Additional contributions by
         HJ Auinger.
@@ -18,7 +18,3 @@ Description: Functions to fit Gaussian linear model by maximising the
 License: GPL 2 | file LICENSE
 URL: http://www.csiro.au
 Suggests: nlme, MASS
-SystemRequirements:
-Packaged: 2012-03-18 22:02:43 UTC; hua032
-Repository: CRAN
-Date/Publication: 2012-03-19 06:52:31

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,6 @@ Description: Functions to fit Gaussian linear model by maximising the
         random effects models. We've added the ability to fit models
         using any kernel as well as a function to return the mean and
         covariance of random effects conditional on the data (BLUPs).
-License: GPL 2 | file LICENSE
+License: GPL-2
 URL: http://www.csiro.au
 Suggests: nlme, MASS

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,10 +1,10 @@
 Package: regress
-Version: 1.3-17
+Version: 1.3-18
 Date: 2020-06-11
 Title: Gaussian Linear Models with Linear Covariance Structure
 Author: David Clifford and Peter McCullagh. Additional contributions by
-        HJ Auinger.
-Maintainer: David Clifford <david.clifford+CRAN@gmail.com>
+        HJ Auinger and Karl W Broman.
+Maintainer: Karl W Broman <broman@wisc.edu>
 Description: Functions to fit Gaussian linear model by maximising the
         residual log likelihood where the covariance structure can be
         written as a linear combination of known matrices.  Can be used

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,5 +16,6 @@ Description: Functions to fit Gaussian linear model by maximising the
         using any kernel as well as a function to return the mean and
         covariance of random effects conditional on the data (BLUPs).
 License: GPL-2
-URL: http://www.csiro.au
+URL: https://github.com/kbroman/regress
+BugReports: https://github.com/kbroman/regress/issues
 Suggests: nlme, MASS

--- a/R/regress.R
+++ b/R/regress.R
@@ -531,7 +531,7 @@ regress <- function(formula, Vformula, identity=TRUE, kernel=NULL,
 
   names(sigma) <- Vcoef.names
   sigma.cov <- try(ginv(FI.c),silent=TRUE)
-  error1 <- (class(sigma.cov)=="try-error")
+  error1 <- ("try-error" %in% class(sigma.cov))
   if(error1) {
     cat("Warning: solution lies on the boundary; check sigma & pos\nNo standard errors for variance components returned\n")
     sigma.cov <- matrix(NA,k,k)

--- a/R/regress.R
+++ b/R/regress.R
@@ -144,7 +144,7 @@ regress <- function(formula, Vformula, identity=TRUE, kernel=NULL,
       Vformula <- as.character(Vformula)
       Vformula[1] <- "~"
       Vformula[2] <- paste(Vformula[2],"+In")
-      Vformula <- as.formula(Vformula)
+      Vformula <- as.formula(paste(Vformula, collapse=" "))
   }
 
   model <- c(model,V)

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 ## Installation
 Please install the package in R directly using the commands:
 
-```R
+```r
 install.packages("devtools")
-devtools::install_github("david-clifford/regress")
+devtools::install_github("kbroman/regress")
 ```
 
 ## References

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # An R package for Gaussian linear models with linear covariance structure
 
+[![Travis build status](https://travis-ci.com/kbroman/regress.svg?branch=master)](https://travis-ci.com/kbroman/regress)
 ## Installation
 Please install the package in R directly using the commands:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # An R package for Gaussian linear models with linear covariance structure
 
 [![Travis build status](https://travis-ci.com/kbroman/regress.svg?branch=master)](https://travis-ci.com/kbroman/regress)
+[![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/regress)](https://cran.r-project.org/package=regress)
+
 ## Installation
 Please install the package in R directly using the commands:
 

--- a/tests/OLS.r
+++ b/tests/OLS.r
@@ -1,3 +1,5 @@
+library(regress)
+
 ## Example of ordinary least squares
 
 x <- rep(1,15)

--- a/tests/predictionVariance.r
+++ b/tests/predictionVariance.r
@@ -1,3 +1,5 @@
+library(regress)
+
 ## Example of prediction variance computations
 
 ## Predictions


### PR DESCRIPTION
1. `as.formula()` can't take a vector, so need to first do `paste(Vformula, collapse=" ")`.

2. Change `class(x) == "try-error"` to `"try-error" %in% class(x)`, for a case where `x` is a matrix, as now in R, a matrix has the vector `c("matrix", "array")` as its class.

3. Add `library(regress)` at the top of two of the test files.

4. Change the maintainer, point to <https://github.com/kbroman/regress>, and add travis checks.