### PR TITLE
Use inherits() to check the class of an object

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: regress
-Version: 1.3-18
+Version: 1.3-19
 Date: 2020-06-11
 Title: Gaussian Linear Models with Linear Covariance Structure
 Author: David Clifford and Peter McCullagh. Additional contributions by

--- a/R/BLUP.R
+++ b/R/BLUP.R
@@ -11,7 +11,7 @@ BLUP <- function(model,RE=NULL) {
 
     if(length(RE)==0) RE <- setdiff(model$Vnames,"In")
     if(any(is.na(match(RE,model$Vnames)))) stop(paste("RE should be a subset of",model$Vnames))
-    if(class(model)!="regress") stop("model should be of class regress")
+    if(!inherits(model, "regress")) stop("model should be of class regress")
 
     ## conditional expected values - all of them
     Wy <- model$W %*% (model$model[[1]] - model$fitted)

--- a/R/regress.R
+++ b/R/regress.R
@@ -343,7 +343,7 @@ regress <- function(formula, Vformula, identity=TRUE, kernel=NULL,
           if (reml) cat(" delta.llik =", delta.llik, "\n") else cat(" delta.llik =", delta.llik, "\n")
         } else cat("\n")
       }
-      
+
       ## now the fun starts, derivative and expected fisher info
       ## the 0.5 multiple is ignored, it is in both and they cancel
 
@@ -531,7 +531,7 @@ regress <- function(formula, Vformula, identity=TRUE, kernel=NULL,
 
   names(sigma) <- Vcoef.names
   sigma.cov <- try(ginv(FI.c),silent=TRUE)
-  error1 <- ("try-error" %in% class(sigma.cov))
+  error1 <- (inherits(sigma.cov, "try-error"))
   if(error1) {
     cat("Warning: solution lies on the boundary; check sigma & pos\nNo standard errors for variance components returned\n")
     sigma.cov <- matrix(NA,k,k)
@@ -543,7 +543,7 @@ regress <- function(formula, Vformula, identity=TRUE, kernel=NULL,
   if(!error1) {
     if(any(sigma[pos]^2 < 1e-4)) cat("Warning: solution lies close to zero for some positive variance components, their standard errors may not be valid\n")
   }
-  
+
   result <- list(trace=stats, llik=llik, cycle=cycle, rdf=rankQ,
                  beta=beta, beta.cov=beta.cov, beta.se=beta.se,
                  sigma=sigma[1:k], sigma.cov=sigma.cov[1:k,1:k], W=W,


### PR DESCRIPTION
- I had changed `class(x)=="try-error"` to `"try-error" %in% class(x)`, but then realized that I should really be doing `inherits(x, "try-error")`. 
- There was one other spot, where I changed `class(model)=="regress"` to `inherits(model, "regress")`.